### PR TITLE
Add flag to close cmake window after successful build and call autocommand events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog][format], and this project adheres to
 * Make the `WinEnter` autocmd in console.vim buffer-local.
 * Set correct source and build directories even when invoking Vim-CMake commands
   from subdirectory of root (source) directory.
+* Implemented user autocommands CMakeBuildFailed and CMakeBuildSuceeded to
+  customize behaviour after :CMakeBuild
 
 <!--=========================================================================-->
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ functionalities run `:help cmake`.  A quick overview follows.
 | `cq`        | Close CMake console window |
 | `<C-C>`     | Stop current command       |
 
+### Events
+
+Vim-CMake provides a set of custom events to trigger further actions.
+Run `:help cmake` for an extensive documentation of all configuration options and examples
+
+| Event                           | Description                               |
+|:--------------------------------|:------------------------------------------|
+| `User CMakeBuildSucceeded`      | Triggered after a successful `:CMakeBuild`|
+| `User CMakeBuildFailed`         | Triggered after a failed `:CMakeBuild`    |
+ 
 ### Quickfix list
 
 After each build (e.g. run with `:CMakeBuild`), Vim-CMake populates a quickfix

--- a/autoload/cmake/console.vim
+++ b/autoload/cmake/console.vim
@@ -113,12 +113,20 @@ function! s:CMakeConsoleCb(data) abort
                 let s:previous_window = winnr()
             endif
             execute bufwinnr(s:console_buffer) . 'wincmd w'
-        elseif g:cmake_jump_on_error
-            if match(a:data, '\m\CErrors have occurred') >= 0
+        endif
+        if match(a:data, '\m\CErrors have occurred') >= 0
+            if g:cmake_jump_on_error
                 if winnr() != bufwinnr(s:console_buffer)
                     let s:previous_window = winnr()
                 endif
                 execute bufwinnr(s:console_buffer) . 'wincmd w'
+            endif
+            if l:cmd_id ==# 'build'
+                doautocmd <nomodeline> User CMakeBuildFailed
+            endif
+        else
+            if l:cmd_id ==# 'build'
+                doautocmd <nomodeline> User CMakeBuildSucceeded
             endif
         endif
     endif

--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -17,10 +17,11 @@ CONTENTS						*cmake-contents*
 4. Mappings ........................................... |cmake-mappings|
    4.1 Global <Plug> mappings ......................... |cmake-plug-mappings|
    4.2 CMake console window key mappings .............. |cmake-key-mappings|
-5. Quickfix list ...................................... |cmake-quickfix|
-6. Configuration ...................................... |cmake-configuration|
-7. Contributing ....................................... |cmake-contributing|
-8. License ............................................ |cmake-license|
+5. Events ............................................. |cmake-events|
+6. Quickfix list ...................................... |cmake-quickfix|
+7. Configuration ...................................... |cmake-configuration|
+8. Contributing ....................................... |cmake-contributing|
+9. License ............................................ |cmake-license|
 
 ==============================================================================
 INTRO							*cmake-intro*
@@ -209,6 +210,28 @@ cq			Close the CMake console window.
 
 <C-C>			Stop the current command.
 
+==============================================================================
+EVENTS							*cmake-events*
+
+To customize the behaviour after a `:CMakeBuild` command has finished, Vim-CMake
+defines some user events.
+
+`CMakeBuildFailed`	Triggered after a build has failed
+`CMakeBuildSucceeded`	Triggered after a build has succeeded
+
+Example usage of `CMakeBuildFailed` to jump to the first error
+>
+	let g:jump_on_error = 0 " We do not want to focus the console
+	augroup vim-cmake-group
+	autocmd User CMakeBuildFailed :cfirst
+	augroup END
+<
+Example usage of `CMakeBuildSucceeded` to close the Vim-CMake console
+>
+	augroup vim-cmake-group
+	autocmd! User CMakeBuildSucceeded CMakeClose
+	augroup END
+<
 ==============================================================================
 QUICKFIX LIST						*cmake-quickfix*
 

--- a/doc/tags
+++ b/doc/tags
@@ -12,6 +12,7 @@ cmake-configuration	cmake.txt	/*cmake-configuration*
 cmake-console	cmake.txt	/*cmake-console*
 cmake-contents	cmake.txt	/*cmake-contents*
 cmake-contributing	cmake.txt	/*cmake-contributing*
+cmake-events	cmake.txt	/*cmake-events*
 cmake-generate	cmake.txt	/*cmake-generate*
 cmake-intro	cmake.txt	/*cmake-intro*
 cmake-key-mappings	cmake.txt	/*cmake-key-mappings*


### PR DESCRIPTION
Implemented a flag to close the window after a successful build #6.
I also added autocommand events after a build fails/succeeds. However, I'm not sure I did it the right way (group user)