### PR TITLE
Proper support for third-party statusline plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog][format], and this project adheres to
 
 ### Added
 * A new configuration option `g:cmake_statusline` controls whether Vim-CMake
-  will set a statusline in the terminal window opened by `:CMake` commands
+  will override the |statusline| option for the CMake console window.
 
 ### Changed
 * `:CMakeOpen` now respects the value of `g:cmake_jump`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog][format], and this project adheres to
 ### Added
 * A new configuration option `g:cmake_statusline` controls whether Vim-CMake
   will override the |statusline| option for the CMake console window.
+* Public API `cmake#GetInfo()` to query information about CMake environment and
+  plugin state.
 
 ### Changed
 * `:CMakeOpen` now respects the value of `g:cmake_jump`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog][format], and this project adheres to
 
 ## Unreleased
 
+### Added
+* A new configuration option `g:cmake_statusline` controls whether Vim-CMake
+  will set a statusline in the terminal window opened by `:CMake` commands
+
 ### Changed
 * `:CMakeOpen` now respects the value of `g:cmake_jump`.
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ function `cmake#GetInfo()` which returns a dictionary containing the
 information. For extensive information run `:help cmake-api`.
 
 To show the CMake version in your statusline you could do:
-	set statusline=%{cmake#GetInfo().cmake_version.string}
+```vim
+set statusline=%{cmake#GetInfo().cmake_version.string}
+```
 or integrate this as a component in your preferred statusline plugin.
 
 <!--=========================================================================-->

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ follows.
 | `g:cmake_link_compile_commands` | `0`                |
 | `g:cmake_root_markers`          | `['.git', '.svn']` |
 | `g:cmake_log_file`              | `''`               |
+| `g:cmake_statusline`            | `1`                |
 
 <!--=========================================================================-->
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ follows.
 
 <!--=========================================================================-->
 
+## Public API
+
+Vim-CMake provides a public API to query information about the CMake
+environment as well as plugin state. The public API consists of a single
+function `cmake#GetInfo()` which returns a dictionary containing the
+information. For extensive information run `:help cmake-api`.
+
+To show the CMake version in your statusline you could do:
+	set statusline=%{cmake#GetInfo().cmake_version.string}
+or integrate this as a component in your preferred statusline plugin.
+
+<!--=========================================================================-->
+
 ## Contributing
 
 Feedback and feature requests are appreciated.  Bug reports and pull requests

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ follows.
 | `g:cmake_link_compile_commands` | `0`                |
 | `g:cmake_root_markers`          | `['.git', '.svn']` |
 | `g:cmake_log_file`              | `''`               |
-| `g:cmake_statusline`            | `1`                |
+| `g:cmake_statusline`            | `0`                |
 
 <!--=========================================================================-->
 

--- a/autoload/cmake.vim
+++ b/autoload/cmake.vim
@@ -164,7 +164,7 @@ function! cmake#Close() abort
     call s:terminal.Close()
 endfunction
 
-" API function for third-party plugins to query status information
+" API function for third-party plugins to query information
 "
 " Returns:
 "     Dictionary
@@ -172,9 +172,19 @@ endfunction
 "             name of the current cmake configuration
 "         status : String
 "             current cmake status (e.g. Building...)
+"         cmake_version : Dictionary
+"             major : Number
+"                 cmake major version
+"             minor : Number
+"                 cmake minor version
+"             patch : Number
+"                 cmake patch version
+"             string : String
+"                 cmake version in string representation
 function! cmake#GetInfo() abort
     let l:info = {}
-    let l:info.config = s:buildsys.GetCurrentConfig()
     let l:info.status = s:terminal.GetCmdInfo()
+    let l:info.config = s:buildsys.GetCurrentConfig()
+    let l:info.cmake_version = s:buildsys.GetCMakeVersion()
     return l:info
 endfunction

--- a/autoload/cmake.vim
+++ b/autoload/cmake.vim
@@ -9,7 +9,6 @@ let s:test = cmake#test#Get()
 let s:const = cmake#const#Get()
 let s:logger = cmake#logger#Get()
 let s:terminal = cmake#terminal#Get()
-let s:statusline = cmake#statusline#Get()
 
 " Print news of new Vim-CMake versions.
 call cmake#util#PrintNews(s:const.plugin_version, s:const.plugin_news)
@@ -168,10 +167,10 @@ endfunction
 "
 " Returns:
 "     Dictionary
-"         config : String
-"             name of the set cmake configuration
 "         status : String
 "             current cmake status (e.g. Building...)
+"         config : String
+"             name of the set cmake configuration
 "         cmake_version : Dictionary
 "             major : Number
 "                 cmake major version
@@ -182,7 +181,7 @@ endfunction
 "             string : String
 "                 cmake version in string representation
 "         project_dir : String
-"             absolute path to the vcs root
+"             absolute path to detected project root (see g:cmake_root_markers)
 "         build_dir : String
 "             absolute path to the build directory for the set configuration
 function! cmake#GetInfo() abort

--- a/autoload/cmake.vim
+++ b/autoload/cmake.vim
@@ -168,13 +168,13 @@ endfunction
 "
 " Returns:
 "     Dictionary
-"         current_config : String
+"         config : String
 "             name of the current cmake configuration
 "         status : String
 "             current cmake status (e.g. Building...)
 function! cmake#GetInfo() abort
     let l:info = {}
-    let l:info.current_config = s:statusline.GetBuildInfo()
-    let l:info.status = s:statusline.GetCmdInfo()
+    let l:info.config = s:buildsys.GetCurrentConfig()
+    let l:info.status = s:terminal.GetCmdInfo()
     return l:info
 endfunction

--- a/autoload/cmake.vim
+++ b/autoload/cmake.vim
@@ -169,7 +169,7 @@ endfunction
 " Returns:
 "     Dictionary
 "         config : String
-"             name of the current cmake configuration
+"             name of the set cmake configuration
 "         status : String
 "             current cmake status (e.g. Building...)
 "         cmake_version : Dictionary
@@ -181,10 +181,16 @@ endfunction
 "                 cmake patch version
 "             string : String
 "                 cmake version in string representation
+"         project_dir : String
+"             absolute path to the vcs root
+"         build_dir : String
+"             absolute path to the build directory for the set configuration
 function! cmake#GetInfo() abort
     let l:info = {}
     let l:info.status = s:terminal.GetCmdInfo()
     let l:info.config = s:buildsys.GetCurrentConfig()
     let l:info.cmake_version = s:buildsys.GetCMakeVersion()
+    let l:info.project_dir = s:buildsys.GetSourceDir()
+    let l:info.build_dir = s:buildsys.GetPathToCurrentConfig()
     return l:info
 endfunction

--- a/autoload/cmake.vim
+++ b/autoload/cmake.vim
@@ -9,6 +9,7 @@ let s:test = cmake#test#Get()
 let s:const = cmake#const#Get()
 let s:logger = cmake#logger#Get()
 let s:terminal = cmake#terminal#Get()
+let s:statusline = cmake#statusline#Get()
 
 " Print news of new Vim-CMake versions.
 call cmake#util#PrintNews(s:const.plugin_version, s:const.plugin_news)
@@ -161,4 +162,19 @@ endfunction
 function! cmake#Close() abort
     call s:logger.LogDebug('API invoked: cmake#Close()')
     call s:terminal.Close()
+endfunction
+
+" API function for third-party plugins to query status information
+"
+" Returns:
+"     Dictionary
+"         current_config : String
+"             name of the current cmake configuration
+"         status : String
+"             current cmake status (e.g. Building...)
+function! cmake#GetInfo() abort
+    let l:info = {}
+    let l:info.current_config = s:statusline.GetBuildInfo()
+    let l:info.status = s:statusline.GetCmdInfo()
+    return l:info
 endfunction

--- a/autoload/cmake/buildsys.vim
+++ b/autoload/cmake/buildsys.vim
@@ -286,7 +286,6 @@ function! s:SetCurrentConfig(config) abort
             \ s:buildsys.current_config,
             \ s:buildsys.path_to_current_config
             \ )
-    call s:statusline.SetBuildInfo(s:buildsys.current_config)
 endfunction
 
 " Link compile commands from source directory to build directory.

--- a/autoload/cmake/buildsys.vim
+++ b/autoload/cmake/buildsys.vim
@@ -4,7 +4,7 @@
 " ==============================================================================
 
 let s:buildsys = {}
-let s:buildsys.cmake_version = 0
+let s:buildsys.cmake_version = {'major': 0, 'minor': 0, 'patch': 0, 'string': ''}
 let s:buildsys.project_root = ''
 let s:buildsys.current_config = ''
 let s:buildsys.path_to_current_config = ''
@@ -326,7 +326,9 @@ function! s:buildsys.Generate(clean, argstring) abort
     " Construct command.
     call extend(l:command, g:cmake_generate_options)
     call extend(l:command, l:optdict.opts)
-    if l:self.cmake_version < 313
+    let l:cmake_version_comparable =
+                \ l:self.cmake_version.major * 100 + l:self.cmake_version.minor
+    if l:cmake_version_comparable < 313
         call add(l:command, '-H' . l:optdict.source_dir)
         call add(l:command, '-B' . l:optdict.build_dir)
     else
@@ -429,6 +431,23 @@ function! s:buildsys.GetCurrentConfig() abort
     return l:self.current_config
 endfunction
 
+" Get CMake version as dict
+"
+" Returns:
+"     Dictionary
+"         major : Number
+"             cmake major version
+"         minor : Number
+"             cmake minor version
+"         patch : Number
+"             cmake patch version
+"         string : String
+"             cmake version in string representation
+"
+function! s:buildsys.GetCMakeVersion() abort
+    return l:self.cmake_version
+endfunction
+
 " Get path to CMake source directory of current project.
 "
 " Returns:
@@ -461,19 +480,21 @@ endfunction
 
 function! s:GetCMakeVersionCb(...) abort
     let l:data = s:system.ExtractStdoutCallbackData(a:000)
-    for l:line in l:data
-        if match(l:line, '\m\C^cmake\S* version') == 0
-            let l:version_str = split(split(l:line)[2], '\.')
-            let l:major = str2nr(l:version_str[0])
-            let l:minor = str2nr(l:version_str[1])
-            let s:buildsys.cmake_version = l:major * 100 + l:minor
-            break
-        endif
-    endfor
+
+    let l:index = match(l:data, '\m\C^cmake\S* version')
+    if l:index != -1
+        let l:version_str = l:data[l:index]->split()[2]
+        let l:version_parts = l:version_str->split('\.')
+        let s:buildsys.cmake_version.major = str2nr(l:version_parts[0])
+        let s:buildsys.cmake_version.minor = str2nr(l:version_parts[1])
+        let s:buildsys.cmake_version.patch = str2nr(l:version_parts[2])
+        let s:buildsys.cmake_version.string = l:version_str
+    endif
 endfunction
 
-" Get CMake version. The version is stored as MAJOR * 100 + MINOR (e.g., version
-" 3.13.3 would result in 313).
+" Get CMake version. The version is stored as a dictionary containing the keys
+" major, minor and patch (e.g., version 3.13.3 would result in the dict
+" {'major': 3, 'minor': 13, 'patch': 3, 'string': '3.13.3'})
 let s:command = [g:cmake_command, '--version']
 call s:system.JobRun(
         \ s:command, v:true, function('s:GetCMakeVersionCb'), v:null, v:false)

--- a/autoload/cmake/buildsys.vim
+++ b/autoload/cmake/buildsys.vim
@@ -483,8 +483,8 @@ function! s:GetCMakeVersionCb(...) abort
 
     let l:index = match(l:data, '\m\C^cmake\S* version')
     if l:index != -1
-        let l:version_str = l:data[l:index]->split()[2]
-        let l:version_parts = l:version_str->split('\.')
+        let l:version_str = split(l:data[l:index])[2]
+        let l:version_parts = split(l:version_str, '\.')
         let s:buildsys.cmake_version.major = str2nr(l:version_parts[0])
         let s:buildsys.cmake_version.minor = str2nr(l:version_parts[1])
         let s:buildsys.cmake_version.patch = str2nr(l:version_parts[2])

--- a/autoload/cmake/const.vim
+++ b/autoload/cmake/const.vim
@@ -41,6 +41,7 @@ let s:const.config_vars = {
         \ 'cmake_link_compile_commands' : 0,
         \ 'cmake_root_markers'          : ['.git', '.svn'],
         \ 'cmake_log_file'              : '',
+        \ 'cmake_statusline'            : 1,
         \ }
 
 " Get const 'object'.

--- a/autoload/cmake/const.vim
+++ b/autoload/cmake/const.vim
@@ -41,7 +41,7 @@ let s:const.config_vars = {
         \ 'cmake_link_compile_commands' : 0,
         \ 'cmake_root_markers'          : ['.git', '.svn'],
         \ 'cmake_log_file'              : '',
-        \ 'cmake_statusline'            : 1,
+        \ 'cmake_statusline'            : 0,
         \ }
 
 " Get const 'object'.

--- a/autoload/cmake/statusline.vim
+++ b/autoload/cmake/statusline.vim
@@ -45,6 +45,26 @@ function! s:statusline.Refresh() abort
     endif
 endfunction
 
+" Get name of current build configuration
+"
+" Returns:
+"     String
+"         name of current build config
+" 
+function! s:statusline.GetBuildInfo() abort
+    return s:statusline.build_info
+endfunction
+
+" Get current command status
+"
+" Returns:
+"     String
+"         statusline command info (command currently running)
+" 
+function! s:statusline.GetCmdInfo() abort
+    return s:statusline.cmd_info
+endfunction
+
 " Get build info string for statusline/airline.
 "
 " Params:

--- a/autoload/cmake/statusline.vim
+++ b/autoload/cmake/statusline.vim
@@ -4,36 +4,10 @@
 " ==============================================================================
 
 let s:statusline = {}
-let s:statusline.build_info = ''
-let s:statusline.cmd_info = ''
-
-let s:logger = cmake#logger#Get()
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Public functions
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-" Set build info string for statusline/airline.
-"
-" Params:
-"     build_info : String
-"         statusline build info
-"
-function! s:statusline.SetBuildInfo(build_info) abort
-    call s:logger.LogDebug('Invoked: statusline.SetBuildInfo(%s)', a:build_info)
-    let l:self.build_info = a:build_info
-endfunction
-
-" Set command info string for statusline/airline.
-"
-" Params:
-"     cmd_info : String
-"         statusline command info
-"
-function! s:statusline.SetCmdInfo(cmd_info) abort
-    call s:logger.LogDebug('Invoked: statusline.SetCmdInfo(%s)', a:cmd_info)
-    let l:self.cmd_info = a:cmd_info
-endfunction
 
 " Force a refresh of the statusline/airline.
 "
@@ -43,26 +17,6 @@ function! s:statusline.Refresh() abort
     else
         execute 'redrawstatus!'
     endif
-endfunction
-
-" Get name of current build configuration
-"
-" Returns:
-"     String
-"         name of current build config
-" 
-function! s:statusline.GetBuildInfo() abort
-    return s:statusline.build_info
-endfunction
-
-" Get current command status
-"
-" Returns:
-"     String
-"         statusline command info (command currently running)
-" 
-function! s:statusline.GetCmdInfo() abort
-    return s:statusline.cmd_info
 endfunction
 
 " Get build info string for statusline/airline.
@@ -77,9 +31,9 @@ endfunction
 "
 function! cmake#statusline#GetBuildInfo(active) abort
     if a:active
-        return s:statusline.build_info
+        return cmake#GetInfo().config
     else
-        return '[' . s:statusline.build_info . ']'
+        return '[' . cmake#GetInfo().config . ']'
     endif
 endfunction
 
@@ -90,8 +44,8 @@ endfunction
 "         statusline command info (command currently running)
 "
 function! cmake#statusline#GetCmdInfo() abort
-    if len(s:statusline.cmd_info) > 0
-        return s:statusline.cmd_info
+    if len(cmake#GetInfo().status) > 0
+        return cmake#GetInfo().status
     else
         return ' '
     endif

--- a/autoload/cmake/terminal.vim
+++ b/autoload/cmake/terminal.vim
@@ -252,8 +252,8 @@ function! s:CreateConsoleBuffer() abort
     setlocal filetype=vimcmake
     if g:cmake_statusline
         setlocal statusline=[CMake]
-        setlocal statusline+=\ %{cmake#statusline#GetBuildInfo(0)}
-        setlocal statusline+=\ %{cmake#statusline#GetCmdInfo()}
+        setlocal statusline+=\ [%{cmake#GetInfo().current_config}]
+        setlocal statusline+=\ %{cmake#GetInfo().status}
     endif
     " Avoid error E37 on :CMakeClose in some Vim instances.
     setlocal bufhidden=hide

--- a/autoload/cmake/terminal.vim
+++ b/autoload/cmake/terminal.vim
@@ -250,9 +250,11 @@ function! s:CreateConsoleBuffer() abort
     setlocal signcolumn=auto
     setlocal nobuflisted
     setlocal filetype=vimcmake
-    setlocal statusline=[CMake]
-    setlocal statusline+=\ %{cmake#statusline#GetBuildInfo(0)}
-    setlocal statusline+=\ %{cmake#statusline#GetCmdInfo()}
+    if g:cmake_statusline
+        setlocal statusline=[CMake]
+        setlocal statusline+=\ %{cmake#statusline#GetBuildInfo(0)}
+        setlocal statusline+=\ %{cmake#statusline#GetCmdInfo()}
+    endif
     " Avoid error E37 on :CMakeClose in some Vim instances.
     setlocal bufhidden=hide
     augroup cmake

--- a/autoload/cmake/terminal.vim
+++ b/autoload/cmake/terminal.vim
@@ -12,6 +12,7 @@ let s:terminal.console_cmd_info = {
         \ 'test': 'Running tests...',
         \ 'NONE': '',
         \ }
+let s:terminal.cmd_info = ''
 let s:terminal.console_cmd = {
         \ 'id': -1,
         \ 'running': v:false,
@@ -151,7 +152,7 @@ function! s:OnCompleteCommand(error, stopped) abort
         let s:exit_term_mode = 1
     endif
     " Update statusline.
-    call s:statusline.SetCmdInfo(s:terminal.console_cmd_info['NONE'])
+    let s:terminal.cmd_info = s:terminal.console_cmd_info['NONE']
     call s:statusline.Refresh()
     " The rest of the tasks are not to be carried out if the running command was
     " stopped by the user.
@@ -252,7 +253,7 @@ function! s:CreateConsoleBuffer() abort
     setlocal filetype=vimcmake
     if g:cmake_statusline
         setlocal statusline=[CMake]
-        setlocal statusline+=\ [%{cmake#GetInfo().current_config}]
+        setlocal statusline+=\ [%{cmake#GetInfo().config}]
         setlocal statusline+=\ %{cmake#GetInfo().status}
     endif
     " Avoid error E37 on :CMakeClose in some Vim instances.
@@ -445,7 +446,7 @@ function! s:terminal.Run(command, tag, cbs, cbs_err, aus, aus_err) abort
                 \ ])
     endif
     " Run command.
-    call s:statusline.SetCmdInfo(l:self.console_cmd_info[a:tag])
+    let s:terminal.cmd_info = l:self.console_cmd_info[a:tag]
     let l:self.console_cmd.id = s:ConsoleCmdStart(a:command)
     " Jump to Vim-CMake console window if requested.
     if g:cmake_jump
@@ -469,6 +470,16 @@ endfunction
 "
 function! s:terminal.GetOutput() abort
     return l:self.console_cmd_output
+endfunction
+
+" Get current command info
+"
+" Returns:
+"     String
+"         current command info
+"
+function! s:terminal.GetCmdInfo() abort
+    return l:self.cmd_info
 endfunction
 
 " Get terminal 'object'.

--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -366,9 +366,9 @@ g:cmake_log_file (default: `''`)
 			Path to a file where to store the log of Vim-CMake.
 			An empty value disables logging.
 
-g:cmake_statusline (default: `1`)
-			Whether to set a custom statusline in the terminal
-			window opened by a `:CMake` command.
+g:cmake_statusline (default: `0`)
+			Whether to override the |statusline| option for the
+			CMake console window.
 
 ==============================================================================
 CONTRIBUTING						*cmake-contributing*

--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -22,8 +22,9 @@ CONTENTS						*cmake-contents*
 5. Events ............................................. |cmake-events|
 6. Quickfix list ...................................... |cmake-quickfix|
 7. Configuration ...................................... |cmake-configuration|
-8. Contributing ....................................... |cmake-contributing|
-9. License ............................................ |cmake-license|
+8. Public API ......................................... |cmake-api|
+9. Contributing ....................................... |cmake-contributing|
+10. License ........................................... |cmake-license|
 
 ==============================================================================
 INTRO							*cmake-intro*
@@ -369,6 +370,51 @@ g:cmake_log_file (default: `''`)
 g:cmake_statusline (default: `0`)
 			Whether to override the |statusline| option for the
 			CMake console window.
+
+==============================================================================
+Public API						*cmake-api*
+
+Vim-CMake provides a public API to query information about the CMake
+environment as well as plugin state. This is intended to be used for
+statusline configuration and third-party plugin integration.
+The public API consists of a single function `cmake#GetInfo()` which returns a
+dictionary of the following structure:
+	status : String
+		current cmake status (e.g. Building...)
+	config : String
+		name of the set cmake configuration
+	cmake_version : Dictionary
+		major : Number
+			cmake major version
+		minor : Number
+			cmake minor version
+		patch : Number
+			cmake patch version
+		string : String
+			cmake version in string representation
+	project_dir : String
+		absolute path to the vcs root
+	build_dir : String
+		absolute path to the build directory for the set configuration
+
+Example return value:
+	{
+	\ 'status': 'Building...',
+	\ 'config': 'Debug',
+	\ 'cmake_version': {
+	  \ 'major': 3,
+	  \ 'minor': 23,
+	  \ 'patch': 2,
+	  \ 'string': '3.23.2',
+	  \},
+	\ 'project_dir': '/home/<user>/<project>',
+	\ 'build_dir': '/home/<user>/<project>/Debug',
+	\}
+
+Example usage:
+To show the CMake version in your statusline you could do:
+	set statusline=%{cmake#GetInfo().cmake_version.string}
+or integrate this as a component in your preferred statusline plugin.
 
 ==============================================================================
 CONTRIBUTING						*cmake-contributing*

--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -366,6 +366,10 @@ g:cmake_log_file (default: `''`)
 			Path to a file where to store the log of Vim-CMake.
 			An empty value disables logging.
 
+g:cmake_statusline (default: `1`)
+			Whether to set a custom statusline in the terminal
+			window opened by a `:CMake` command.
+
 ==============================================================================
 CONTRIBUTING						*cmake-contributing*
 

--- a/doc/tags
+++ b/doc/tags
@@ -8,6 +8,7 @@
 :CMakeSwitch	cmake.txt	/*:CMakeSwitch*
 :CMakeTest	cmake.txt	/*:CMakeTest*
 cmake	cmake.txt	/*cmake*
+cmake-api	cmake.txt	/*cmake-api*
 cmake-build	cmake.txt	/*cmake-build*
 cmake-commands	cmake.txt	/*cmake-commands*
 cmake-configuration	cmake.txt	/*cmake-configuration*


### PR DESCRIPTION
This variable sets whether vim-cmake sets a custom statusline in the terminal window opened by :CMake commands.

This is an implementation of my proposed changes in #46.

I'm currently not too sure about the name of the variable added. Please comment with ideas regarding this or other parts of this change. The name from #46 would create a double negative though and doesn't seem like a good idea.

Feel free to close this if you don't think this change is a good idea since you haven't answered on the issue yet.