### PR TITLE
Do not escape paths in `s:system.Path()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog][format], and this project adheres to
 
 ## Unreleased
 
+### Changed
+* `s:system.Path()` does not escape file paths, as it is unnecessary, and it
+  even causes issues in some cases (#78).
+
 <!--=========================================================================-->
 
 ## 0.12.0 &ndash; 2022-11-09

--- a/autoload/cmake/system.vim
+++ b/autoload/cmake/system.vim
@@ -71,9 +71,8 @@ function! s:system.Path(components, relative) abort
             let l:path = fnamemodify(l:path, ':.')
         endif
     endif
-    " Simplify and escape path.
+    " Simplify path.
     let l:path = simplify(l:path)
-    let l:path = fnameescape(l:path)
     return l:path
 endfunction
 


### PR DESCRIPTION
To test:
- [x] Vim on Linux
- [x] Neovim on Windows