### PR TITLE
.gitmodules relative path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "autoload/libs"]
 	path = autoload/libs
-	url = git@github.com:cdelledonne/vim-libs.git
+	url = ../../cdelledonne/vim-libs.git


### PR DESCRIPTION
I'm using vim-cmake in a docker image, where vim-cmake is cloned with https, but the submodule vim-libs uses ssh and this breaks the build.
Replacing the url with a relative path pointing at the vim-libs submodule should work in all cases, both when using ssh and https. I've tested both the docker build and a regular submodule update using an ssh clone, both work.