### PR TITLE
Add --recurse-submodules to git-clone installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ or Vim's native package manager:
 ```sh
 mkdir -p ~/.vim/pack/plug/start
 cd ~/.vim/pack/plug/start
-git clone https://github.com/cdelledonne/vim-cmake.git
+git clone --recurse-submodules https://github.com/cdelledonne/vim-cmake.git
 ```
 
 <!--=========================================================================-->


### PR DESCRIPTION
The plugin doesn't work if it's installed without it, failing with

Error detected while processing [...]/vim-cmake/plugin/cmake.vim:
line   24:
E117: Unknown function: libs#logger#Get

and other similar errors.

----

It took me some time what was going on after installing the plugin, so I hope that mentioning this here should help others avoid wasting time on this.